### PR TITLE
fix the package name command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Installations
 ```
-npm i discord-youtube-notifications
+npm i discord-bot-youtube-notifications
 ```
 
 # What?


### PR DESCRIPTION
I tried to install the package, but it isn't found, so I needed to install the package via this Github repo.

I saw the metadata of the package, and it seems like the package is called `discord-bot-youtube-notifications` instead of `discord-youtube-notifications`

Thanks for the package, will try in a few minutes!